### PR TITLE
✨[FEAT] #29: 홈화면 관련 API

### DIFF
--- a/src/main/java/Oops/backend/common/status/ErrorStatus.java
+++ b/src/main/java/Oops/backend/common/status/ErrorStatus.java
@@ -31,6 +31,9 @@ public enum ErrorStatus {
     // 사용자 관련 에러
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER404", "해당 사용자를 찾을 수 없습니다."),
 
+    // 랜덤 주제 관련 에러
+    INVALID_TOPIC_ID(HttpStatus.BAD_REQUEST, "TOPIC400", "해당 랜덤 주제 ID는 존재하지 않습니다. 1 ~ 20 범위 내의 ID를 요청해주세요. "),
+
     // 카테고리 관련 에러
     CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "CATEGORY404", "해당 카테고리를 찾을 수 없습니다."),
     INVALID_CATEGORY_ID(HttpStatus.BAD_REQUEST, "CATEGORY400", "해당 카테고리 ID는 존재하지 않습니다. 1 ~ 15 범위 내의 ID를 요청해주세요. "),

--- a/src/main/java/Oops/backend/config/SecurityConfig.java
+++ b/src/main/java/Oops/backend/config/SecurityConfig.java
@@ -21,7 +21,7 @@ public class SecurityConfig {
         http
                 .csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/auth/**", "/swagger-ui/**", "/v3/api-docs/**", "/api/posts/**", "/api/categories/**").permitAll()
+                        .requestMatchers("/api/auth/**", "/swagger-ui/**", "/v3/api-docs/**", "/api/posts/**", "/api/categories/**", "/api/feeds/**").permitAll()
                         .anyRequest().authenticated()
                 )
                 .formLogin(config -> config.disable())

--- a/src/main/java/Oops/backend/domain/category/controller/CategoryController.java
+++ b/src/main/java/Oops/backend/domain/category/controller/CategoryController.java
@@ -4,17 +4,13 @@ import Oops.backend.common.exception.GeneralException;
 import Oops.backend.common.response.BaseResponse;
 import Oops.backend.common.status.ErrorStatus;
 import Oops.backend.common.status.SuccessStatus;
+import Oops.backend.domain.auth.AuthenticatedUser;
 import Oops.backend.domain.category.dto.CategoryResponse;
-import Oops.backend.domain.category.entity.Category;
 import Oops.backend.domain.category.service.CategoryService;
-import Oops.backend.domain.auth.AuthenticationContext;
 import Oops.backend.domain.user.entity.User;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -25,20 +21,14 @@ import java.util.List;
 @RequestMapping("/api/categories")
 public class CategoryController {
     private final CategoryService categoryService;
-    private final AuthenticationContext authenticationContext;
 
     /**
      * 전체 카테고리명 조회
      */
     @GetMapping
     @Operation(summary = "전체 카테고리 조회 API",description = "전체 15개의 카테고리를 조회하는 api이며, 카테고리 이름과 즐겨찾기 여부를 반환합니다.")
-    public ResponseEntity<BaseResponse> getCategoryList() {
-        User currentUser = authenticationContext.getPrincipal();
-        if (currentUser == null){
-            throw new GeneralException(ErrorStatus.USER_NOT_FOUND);
-        }
-
-        List<CategoryResponse.CategoryResponseDto> result = categoryService.getCategories(currentUser);
+    public ResponseEntity<BaseResponse> getCategoryList(@Parameter(hidden = true) @AuthenticatedUser User user) {
+        List<CategoryResponse.CategoryResponseDto> result = categoryService.getCategories(user);
         return BaseResponse.onSuccess(SuccessStatus._OK, result);
     }
 
@@ -47,18 +37,13 @@ public class CategoryController {
      */
     @GetMapping("/search")
     @Operation(summary = "카테고리 검색 API",description = "카테고리를 이름으로 검색하는 API로 즐겨찾기 여부까지 반환됩니다.")
-    public ResponseEntity<BaseResponse> searchCategoriesByName(@RequestParam("name") String searchName) {
-        User currentUser = authenticationContext.getPrincipal();
-        // 사용자가 존재하는지 확인
-        if (currentUser == null){
-            throw new GeneralException(ErrorStatus.USER_NOT_FOUND);
-        }
+    public ResponseEntity<BaseResponse> searchCategoriesByName(@RequestParam("name") String searchName, @Parameter(hidden = true) @AuthenticatedUser User user) {
         // 검색어가 비어 있지 않은지 확인
         if (searchName == null || searchName.isEmpty()) {
             throw new GeneralException(ErrorStatus.INVALID_SEARCH_KEYWORD);
         }
 
-        List<CategoryResponse.CategoryResponseDto> result = categoryService.searchCategory(searchName, currentUser);
+        List<CategoryResponse.CategoryResponseDto> result = categoryService.searchCategory(searchName, user);
         return BaseResponse.onSuccess(SuccessStatus._OK, result);
     }
 
@@ -67,13 +52,8 @@ public class CategoryController {
      */
     @PostMapping("/{categoryId}/bookmark")
     @Operation(summary = "카테고리 즐겨찾기 설정 API",description = "선택된 카테고리를 즐겨찾기로 설정합니다.")
-    public ResponseEntity<BaseResponse> bookmarked (@PathVariable Long categoryId) {
-        User currentUser = authenticationContext.getPrincipal();
-        // 사용자가 존재하는지 확인
-        if (currentUser == null){
-            throw new GeneralException(ErrorStatus.USER_NOT_FOUND);
-        }
-        categoryService.addFavoriteCategory(categoryId, currentUser);
+    public ResponseEntity<BaseResponse> bookmarked (@PathVariable Long categoryId, @Parameter(hidden = true) @AuthenticatedUser User user) {
+        categoryService.addFavoriteCategory(categoryId, user);
         return BaseResponse.onSuccess(SuccessStatus._OK);
     }
 
@@ -82,13 +62,8 @@ public class CategoryController {
      */
     @DeleteMapping("/{categoryId}/unbookmark")
     @Operation(summary = "카테고리 즐겨찾기 해제 API",description = "선택된 카테고리를 즐겨찾기 해제합니다.")
-    public ResponseEntity<BaseResponse> unbookmarked (@PathVariable Long categoryId) {
-        User currentUser = authenticationContext.getPrincipal();
-        // 사용자가 존재하는지 확인
-        if (currentUser == null){
-            throw new GeneralException(ErrorStatus.USER_NOT_FOUND);
-        }
-        categoryService.deleteFavoriteCategory(categoryId, currentUser);
+    public ResponseEntity<BaseResponse> unbookmarked (@PathVariable Long categoryId, @Parameter(hidden = true) @AuthenticatedUser User user) {
+        categoryService.deleteFavoriteCategory(categoryId, user);
         return BaseResponse.onSuccess(SuccessStatus._OK);
     }
 

--- a/src/main/java/Oops/backend/domain/category/dto/CategoryResponse.java
+++ b/src/main/java/Oops/backend/domain/category/dto/CategoryResponse.java
@@ -8,7 +8,7 @@ import lombok.NoArgsConstructor;
 public class CategoryResponse {
 
     /**
-     * 전체 카테고리 목록 조회
+     * 카테고리 조회
      */
     @Builder
     @Getter

--- a/src/main/java/Oops/backend/domain/category/service/CategoryServiceImpl.java
+++ b/src/main/java/Oops/backend/domain/category/service/CategoryServiceImpl.java
@@ -9,9 +9,6 @@ import Oops.backend.domain.category.repository.UserAndCategoryRepository;
 import Oops.backend.domain.user.entity.User;
 import Oops.backend.domain.user.entity.UserAndCategory;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,7 +17,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-@Slf4j
 @Service
 @RequiredArgsConstructor
 public class CategoryServiceImpl implements CategoryService {

--- a/src/main/java/Oops/backend/domain/post/controller/FeedsController.java
+++ b/src/main/java/Oops/backend/domain/post/controller/FeedsController.java
@@ -1,0 +1,50 @@
+package Oops.backend.domain.post.controller;
+
+import Oops.backend.common.exception.GeneralException;
+import Oops.backend.common.response.BaseResponse;
+import Oops.backend.common.status.ErrorStatus;
+import Oops.backend.common.status.SuccessStatus;
+import Oops.backend.domain.auth.AuthenticatedUser;
+import Oops.backend.domain.auth.AuthenticationContext;
+import Oops.backend.domain.category.dto.CategoryResponse;
+import Oops.backend.domain.category.service.CategoryService;
+import Oops.backend.domain.post.dto.PostResponse;
+import Oops.backend.domain.post.service.FeedService;
+import Oops.backend.domain.user.entity.User;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/feeds")
+public class FeedsController {
+    private final FeedService feedService;
+
+    /**
+     * 홈화면 첫 로딩
+     */
+    @GetMapping("/home/first")
+    @Operation(summary = "홈화면 첫 로딩 API",description = "홈화면 처음 로딩 시 필요한 베스트 실패담 5개와 즐겨찾기한 실패담 10개만 우선 조회합니다.")
+    public ResponseEntity<BaseResponse> getFirstPostList(@Parameter(hidden = true) @AuthenticatedUser User user) {
+
+        List<PostResponse.PostPreviewListDto> result = feedService.getFirstPostList(user);
+        return BaseResponse.onSuccess(SuccessStatus._OK, result);
+    }
+
+    /**
+     * 홈 화면 이후 로딩
+     */
+    @GetMapping("/home/later")
+    @Operation(summary = "홈화면 이후 로딩 API",description ="카테고리별 최신글 하나씩 조회합니다.")
+    public ResponseEntity<BaseResponse> getLaterPostList() {
+        PostResponse.PostPreviewListDto result = feedService.getLaterPostList();
+        return BaseResponse.onSuccess(SuccessStatus._OK, result);
+    }
+}

--- a/src/main/java/Oops/backend/domain/post/controller/FeedsController.java
+++ b/src/main/java/Oops/backend/domain/post/controller/FeedsController.java
@@ -14,9 +14,13 @@ import Oops.backend.domain.user.entity.User;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -45,6 +49,21 @@ public class FeedsController {
     @Operation(summary = "홈화면 이후 로딩 API",description ="카테고리별 최신글 하나씩 조회합니다.")
     public ResponseEntity<BaseResponse> getLaterPostList() {
         PostResponse.PostPreviewListDto result = feedService.getLaterPostList();
+        return BaseResponse.onSuccess(SuccessStatus._OK, result);
+    }
+
+    /**
+     * 실패담 검색
+     */
+    @GetMapping("/search")
+    @Operation(summary = "실패담 검색 API",description ="검색어가 제목, 내용, 카테고리에 포함된 모든 글들을 최신순으로 조회한다. 페이지는 0부터 시작한다.")
+    public ResponseEntity<BaseResponse> getAllPostsByKeyword(@RequestParam String keyword,
+                                                             @RequestParam(defaultValue = "0") int page,
+                                                             @RequestParam(defaultValue = "10") int limit) {
+
+        Pageable pageable = PageRequest.of(page, limit, Sort.by(Sort.Direction.DESC, "createdAt"));
+        PostResponse.PostPreviewListDto result = feedService.searchPosts(keyword, pageable);
+
         return BaseResponse.onSuccess(SuccessStatus._OK, result);
     }
 }

--- a/src/main/java/Oops/backend/domain/post/dto/PostResponse.java
+++ b/src/main/java/Oops/backend/domain/post/dto/PostResponse.java
@@ -1,5 +1,6 @@
 package Oops.backend.domain.post.dto;
 
+import Oops.backend.domain.post.entity.Post;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -24,6 +25,19 @@ public class PostResponse {
         int comments;
         int views;
         String image;  // 대표 이미지 한 장
+
+        public static PostPreviewDto from(Post post) {
+            return PostResponse.PostPreviewDto.builder()
+                    .postId(post.getId())
+                    .title(post.getTitle())
+                    .content(post.getContent())
+                    .categoryName(post.getCategory().getName())
+                    .likes(post.getLikes())
+                    .comments(post.getComments() != null ? post.getComments().size() : 0)
+                    .views(post.getWatching())
+                    .image(post.getImages() != null && !post.getImages().isEmpty() ? post.getImages().get(0) : null)
+                    .build();
+        }
     }
 
     /**
@@ -36,5 +50,6 @@ public class PostResponse {
     public static class PostPreviewListDto {
         String name;   // 베스트 or 즐겨찾기 or 카테고리
         List<PostPreviewDto> posts;
+        boolean isLast;
     }
 }

--- a/src/main/java/Oops/backend/domain/post/dto/PostResponse.java
+++ b/src/main/java/Oops/backend/domain/post/dto/PostResponse.java
@@ -1,0 +1,40 @@
+package Oops.backend.domain.post.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+public class PostResponse {
+    /**
+     * 홈화면에 출력될 각 실패담의 preview 정보
+     */
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class PostPreviewDto {
+        Long postId;
+        String title;
+        String content;
+        String categoryName;
+        int likes;
+        int comments;
+        int views;
+        String image;  // 대표 이미지 한 장
+    }
+
+    /**
+     * PostPreviewDto를 담는 리스트
+     */
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class PostPreviewListDto {
+        String name;   // 베스트 or 즐겨찾기 or 카테고리
+        List<PostPreviewDto> posts;
+    }
+}

--- a/src/main/java/Oops/backend/domain/post/repository/PostRepository.java
+++ b/src/main/java/Oops/backend/domain/post/repository/PostRepository.java
@@ -1,7 +1,55 @@
 package Oops.backend.domain.post.repository;
 
 import Oops.backend.domain.post.entity.Post;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
+
+    /**
+     * 베스트 실패담 5개 조회
+     */
+    @Query("SELECT p FROM Post p " +
+            "LEFT JOIN p.comments c " +
+            "WHERE p.createdAt <= :cutoff " +
+            "GROUP BY p " +
+            "ORDER BY (p.watching + 5 * p.likes + 10 * COUNT(c)) DESC")
+    List<Post> findTopBestPostBefore(@Param("cutoff") LocalDateTime cutoff, Pageable pageable);
+
+    /**
+     * 즐찾 카테고리 중 최신 실패담 10개 조회
+     */
+    @Query("SELECT p FROM Post p WHERE p.category.id IN :categoryIds ORDER BY p.createdAt DESC")
+    List<Post> findTop10ByCategoryIdsOrderByCreatedAtDesc(@Param("categoryIds") List<Long> categoryIds, Pageable pageable);
+
+    /**
+     * 각 카테고리별 최신글 1개씩 조회
+     */
+    @Query(value = """
+    SELECT p.* FROM post p
+    INNER JOIN (
+        SELECT category, MAX(created_at) AS max_created
+        FROM post
+        GROUP BY category
+    ) latest ON p.category = latest.category AND p.created_at = latest.max_created
+    """, nativeQuery = true)
+    List<Post> findLatestPostPerCategory();
+
+    /**
+     * 저번 주 랜덤 주제에 대한 게시글 조회
+     */
+    @Query("SELECT p FROM Post p " +
+            "LEFT JOIN p.comments c " +
+            "WHERE p.topic.id = :topicId AND p.createdAt <= :cutoff " +
+            "GROUP BY p " +
+            "ORDER BY (p.watching + 5 * p.likes + 10 * COUNT(c)) DESC")
+    List<Post> findTop3BestPostsByTopic(@Param("topicId") Long topicId,
+                                        @Param("cutoff") LocalDateTime cutoff,
+                                        Pageable pageable);
 }

--- a/src/main/java/Oops/backend/domain/post/repository/PostRepository.java
+++ b/src/main/java/Oops/backend/domain/post/repository/PostRepository.java
@@ -1,7 +1,7 @@
 package Oops.backend.domain.post.repository;
 
 import Oops.backend.domain.post.entity.Post;
-import org.springframework.data.domain.Page;
+import Oops.backend.domain.category.entity.Category;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -52,4 +52,15 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     List<Post> findTop3BestPostsByTopic(@Param("topicId") Long topicId,
                                         @Param("cutoff") LocalDateTime cutoff,
                                         Pageable pageable);
+
+    /**
+     * 제목 또는 본문에 해당 키워드가 포함된 게시글 조회
+     */
+    @Query("SELECT p FROM Post p WHERE p.title LIKE %:keyword% OR p.content LIKE %:keyword%")
+    List<Post> findByKeyword(@Param("keyword") String keyword);
+
+    /**
+     * 특정 카테고리 리스트에 포함된 게시글
+     */
+    List<Post> findByCategoryIn(List<Category> categories);
 }

--- a/src/main/java/Oops/backend/domain/post/service/FeedService.java
+++ b/src/main/java/Oops/backend/domain/post/service/FeedService.java
@@ -2,10 +2,12 @@ package Oops.backend.domain.post.service;
 
 import Oops.backend.domain.post.dto.PostResponse;
 import Oops.backend.domain.user.entity.User;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
 public interface FeedService {
     List<PostResponse.PostPreviewListDto> getFirstPostList(User user);
     PostResponse.PostPreviewListDto getLaterPostList();
+    PostResponse.PostPreviewListDto searchPosts(String keyword, Pageable pageable);
 }

--- a/src/main/java/Oops/backend/domain/post/service/FeedService.java
+++ b/src/main/java/Oops/backend/domain/post/service/FeedService.java
@@ -1,0 +1,11 @@
+package Oops.backend.domain.post.service;
+
+import Oops.backend.domain.post.dto.PostResponse;
+import Oops.backend.domain.user.entity.User;
+
+import java.util.List;
+
+public interface FeedService {
+    List<PostResponse.PostPreviewListDto> getFirstPostList(User user);
+    PostResponse.PostPreviewListDto getLaterPostList();
+}

--- a/src/main/java/Oops/backend/domain/post/service/FeedServiceImpl.java
+++ b/src/main/java/Oops/backend/domain/post/service/FeedServiceImpl.java
@@ -1,0 +1,118 @@
+package Oops.backend.domain.post.service;
+
+import Oops.backend.domain.category.repository.UserAndCategoryRepository;
+import Oops.backend.domain.post.dto.PostResponse;
+import Oops.backend.domain.post.entity.Post;
+import Oops.backend.domain.post.repository.PostRepository;
+import Oops.backend.domain.user.entity.User;
+import Oops.backend.domain.user.entity.UserAndCategory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class FeedServiceImpl implements FeedService {
+    private final PostRepository postRepository;
+    private final UserAndCategoryRepository userAndCategoryRepository;
+
+    /**
+     * 홈화면 첫로딩
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public List<PostResponse.PostPreviewListDto> getFirstPostList(User user) {
+
+        List<PostResponse.PostPreviewListDto> result = new ArrayList<>();
+
+        // 1. 전날 23:59까지 작성된 글 중 베스트 실패담 5개 조회
+        LocalDateTime cutoff = LocalDate.now().atStartOfDay().minusSeconds(1);
+        List<Post> bestPosts = postRepository.findTopBestPostBefore(cutoff, PageRequest.of(0, 5));
+
+        List<PostResponse.PostPreviewDto> bestPreviewDtos = bestPosts.stream()
+                .map(this::convertToPreviewDto)
+                .collect(Collectors.toList());
+
+        PostResponse.PostPreviewListDto bestListDto = PostResponse.PostPreviewListDto.builder()
+                .name("베스트 Failers")
+                .posts(bestPreviewDtos)
+                .build();
+
+        result.add(bestListDto); // 항상 베스트 리스트는 추가
+
+        // 2. 즐겨찾기한 카테고리의 최신 글 10개 조회
+        List<UserAndCategory> userCategories = userAndCategoryRepository.findByUserId(user.getId());
+        List<Long> categoryIds = userCategories.stream()
+                .map(uc -> uc.getCategory().getId())
+                .collect(Collectors.toList());
+
+        if (categoryIds.isEmpty()) {  // 즐겨찾기한 카테고리가 없는 경우
+            PostResponse.PostPreviewListDto emptyListDto = PostResponse.PostPreviewListDto.builder()
+                    .name("즐겨찾기한 카테고리가 없습니다.")
+                    .posts(Collections.emptyList())
+                    .build();
+
+            result.add(emptyListDto);
+            return result;
+        }
+
+        Pageable topTen = PageRequest.of(0, 10);
+        List<Post> posts = postRepository.findTop10ByCategoryIdsOrderByCreatedAtDesc(categoryIds, topTen);
+
+        List<PostResponse.PostPreviewDto> markedPreviewDtos = posts.stream()
+                .map(this::convertToPreviewDto)
+                .collect(Collectors.toList());
+
+        PostResponse.PostPreviewListDto markedListDto = PostResponse.PostPreviewListDto.builder()
+                .name("즐겨찾기한 카테고리")
+                .posts(markedPreviewDtos)
+                .build();
+
+        result.add(markedListDto);
+
+        return result;
+    }
+
+    private PostResponse.PostPreviewDto convertToPreviewDto(Post post) {
+        return PostResponse.PostPreviewDto.builder()
+                .postId(post.getId())
+                .title(post.getTitle())
+                .content(post.getContent())
+                .categoryName(post.getCategory().getName())
+                .likes(post.getLikes())
+                .comments(post.getComments() != null ? post.getComments().size() : 0)
+                .views(post.getWatching())
+                .image(post.getImages() != null && !post.getImages().isEmpty() ? post.getImages().get(0) : null)
+                .build();
+    }
+
+    /**
+     * 홈화면 이후 로딩
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public PostResponse.PostPreviewListDto getLaterPostList() {
+        List<Post> latestPostPerCategories = postRepository.findLatestPostPerCategory();
+
+        List<PostResponse.PostPreviewDto> previewDtos = latestPostPerCategories.stream()
+                .map(this::convertToPreviewDto)
+                .collect(Collectors.toList());
+
+        PostResponse.PostPreviewListDto listDto = PostResponse.PostPreviewListDto.builder()
+                .name("카테고리 목록")
+                .posts(previewDtos)
+                .build();
+
+        return listDto;
+    }
+
+}

--- a/src/main/java/Oops/backend/domain/randomTopic/Repository/RandomTopicRepository.java
+++ b/src/main/java/Oops/backend/domain/randomTopic/Repository/RandomTopicRepository.java
@@ -1,0 +1,8 @@
+package Oops.backend.domain.randomTopic.Repository;
+
+import Oops.backend.domain.randomTopic.entity.RandomTopic;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+
+public interface RandomTopicRepository extends JpaRepository<RandomTopic, Long> {
+}

--- a/src/main/java/Oops/backend/domain/randomTopic/Service/RandomTopicService.java
+++ b/src/main/java/Oops/backend/domain/randomTopic/Service/RandomTopicService.java
@@ -1,0 +1,8 @@
+package Oops.backend.domain.randomTopic.Service;
+
+import Oops.backend.domain.randomTopic.dto.RandomTopicResponse;
+import Oops.backend.domain.user.entity.User;
+
+public interface RandomTopicService {
+    RandomTopicResponse.BannarsInfoDto getBannarInfo(Long currentTopicId, User user);
+}

--- a/src/main/java/Oops/backend/domain/randomTopic/Service/RandomTopicServiceImpl.java
+++ b/src/main/java/Oops/backend/domain/randomTopic/Service/RandomTopicServiceImpl.java
@@ -1,0 +1,62 @@
+package Oops.backend.domain.randomTopic.Service;
+
+import Oops.backend.common.exception.GeneralException;
+import Oops.backend.common.status.ErrorStatus;
+import Oops.backend.domain.post.entity.Post;
+import Oops.backend.domain.post.repository.PostRepository;
+import Oops.backend.domain.randomTopic.Repository.RandomTopicRepository;
+import Oops.backend.domain.randomTopic.dto.RandomTopicResponse;
+import Oops.backend.domain.randomTopic.entity.RandomTopic;
+import Oops.backend.domain.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class RandomTopicServiceImpl implements RandomTopicService {
+
+    private final RandomTopicRepository randomTopicRepository;
+    private final PostRepository postRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public RandomTopicResponse.BannarsInfoDto getBannarInfo(Long lastTopicId, User user){
+        // 요청 유효성 검증
+        if (lastTopicId == null) {
+            throw new GeneralException(ErrorStatus._BAD_REQUEST);
+        }else if (lastTopicId < 1 || lastTopicId > 20) {
+            throw new GeneralException(ErrorStatus.INVALID_TOPIC_ID);
+        }
+
+        // 지난주, 이번주 랜덤 주제 조회
+        RandomTopic lastTopic = randomTopicRepository.findById(lastTopicId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus._INTERNAL_SERVER_ERROR));
+
+        Long currentTopicId = lastTopic.getNextTopicId();
+
+        RandomTopic currentTopic = randomTopicRepository.findById(currentTopicId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus._INTERNAL_SERVER_ERROR));
+
+        // 사용자가 저번주 주제에 대하여 인기글에 선정되었는지 여부
+        LocalDateTime cutoff = LocalDate.now().atStartOfDay().minusSeconds(1);
+        List<Post> bestPosts = postRepository.findTop3BestPostsByTopic(lastTopicId, cutoff, PageRequest.of(0, 3));
+
+        boolean isBestUser = bestPosts.stream()
+                .anyMatch(post -> post.getUser().getId().equals(user.getId()));
+
+        // 결과 반환
+        return RandomTopicResponse.BannarsInfoDto.builder()
+                .lastTopicId(lastTopicId)
+                .lastTopicName(lastTopic.getName())
+                .currentTopicId(currentTopicId)
+                .currentTopicName(currentTopic.getName())
+                .isBestUser(isBestUser)
+                .build();
+    }
+}

--- a/src/main/java/Oops/backend/domain/randomTopic/controller/RandomTopicController.java
+++ b/src/main/java/Oops/backend/domain/randomTopic/controller/RandomTopicController.java
@@ -1,0 +1,34 @@
+package Oops.backend.domain.randomTopic.controller;
+
+import Oops.backend.common.exception.GeneralException;
+import Oops.backend.common.response.BaseResponse;
+import Oops.backend.common.status.ErrorStatus;
+import Oops.backend.common.status.SuccessStatus;
+import Oops.backend.domain.auth.AuthenticatedUser;
+import Oops.backend.domain.post.dto.PostResponse;
+import Oops.backend.domain.randomTopic.Service.RandomTopicService;
+import Oops.backend.domain.randomTopic.dto.RandomTopicResponse;
+import Oops.backend.domain.user.entity.User;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/feeds")
+public class RandomTopicController {
+
+    private final RandomTopicService randomTopicService;
+
+    @GetMapping("/banners")
+    @Operation(summary = "홈화면 배너 API",description = "홈화면의 배너에 필요한 정보를 조회하는 api입니다. currentTopicId에는 이번주 랜덤 주제 (이제 저번주 주제가 될) 아이디를 넣어주세요. ")
+    public ResponseEntity<BaseResponse> getBannarInfo (Long currentTopicId, @Parameter(hidden = true) @AuthenticatedUser User user) {
+
+        RandomTopicResponse.BannarsInfoDto result = randomTopicService.getBannarInfo(currentTopicId, user);
+        return BaseResponse.onSuccess(SuccessStatus._OK, result);
+    }
+}

--- a/src/main/java/Oops/backend/domain/randomTopic/dto/RandomTopicResponse.java
+++ b/src/main/java/Oops/backend/domain/randomTopic/dto/RandomTopicResponse.java
@@ -1,0 +1,25 @@
+package Oops.backend.domain.randomTopic.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class RandomTopicResponse {
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class BannarsInfoDto {
+        // 저번주 랜덤 주제
+        Long lastTopicId;
+        String lastTopicName;
+
+        // 이번주 랜덤 주제
+        Long currentTopicId;
+        String currentTopicName;
+
+        // 저번주 주제에 대한 사용자 당첨 여부
+        boolean isBestUser;
+    }
+}

--- a/src/main/java/Oops/backend/domain/randomTopic/entity/RandomTopic.java
+++ b/src/main/java/Oops/backend/domain/randomTopic/entity/RandomTopic.java
@@ -16,8 +16,5 @@ public class RandomTopic extends BaseEntity {
     private String name;
 
     @Column(nullable = false)
-    private LocalDate startDate;
-
-    @Column(nullable = false)
-    private LocalDate endDate;
+    private Long nextTopicId;
 }


### PR DESCRIPTION
## #⃣ 연관된 이슈

> #29 

## 📝 작업 내용

> 홈화면에 필요한 배너 정보, 베스트 실패담, 즐겨찾기한 카테고리의 실패담, 각 카테고리별 실패담 조회하는 api 구현 
