### PR TITLE
[REFACTOR] #139 로그인 여부 상관 없이 홈화면 보여주도록 API 분리

### DIFF
--- a/src/main/java/Oops/backend/domain/auth/AuthenticationConfig.java
+++ b/src/main/java/Oops/backend/domain/auth/AuthenticationConfig.java
@@ -21,6 +21,7 @@ public class AuthenticationConfig implements WebMvcConfigurer {
                 .excludePathPatterns(
                         "/api/auth/login",
                         "/api/auth/join",
+                        "/api/feeds/home/first-guest",
                         "/hello",
                         "/health",
                         "/public/**",

--- a/src/main/java/Oops/backend/domain/auth/service/AuthService.java
+++ b/src/main/java/Oops/backend/domain/auth/service/AuthService.java
@@ -72,7 +72,7 @@ public class AuthService {
         log.info("AccessToken: " + accessToken);
         log.info("UserName: "+ user.getUserName());
         ResponseCookie cookie = ResponseCookie.from("AccessToken", JwtEncoder.encodeJwtBearerToken(accessToken))
-                .maxAge(Duration.ofMillis(1800000))
+                .maxAge(Duration.ofMillis(60000))
                 .httpOnly(true)
                 .sameSite("LAX")
                 .secure(false)

--- a/src/main/java/Oops/backend/domain/post/controller/HomeFeedController.java
+++ b/src/main/java/Oops/backend/domain/post/controller/HomeFeedController.java
@@ -3,6 +3,7 @@ package Oops.backend.domain.post.controller;
 import Oops.backend.common.response.BaseResponse;
 import Oops.backend.common.status.SuccessStatus;
 import Oops.backend.domain.auth.AuthenticatedUser;
+import Oops.backend.domain.auth.AuthenticationContext;
 import Oops.backend.domain.post.dto.PostResponse;
 import Oops.backend.domain.post.service.HomeFeedService;
 import Oops.backend.domain.user.entity.User;
@@ -27,13 +28,24 @@ public class HomeFeedController {
     private final HomeFeedService feedService;
 
     /**
-     * 홈화면 첫 로딩
+     * 홈화면 첫 로딩 - 로그인 O
      */
-    @GetMapping("/home/first")
-    @Operation(summary = "홈화면 첫 로딩 API",description = "홈화면 처음 로딩 시 필요한 베스트 실패담 5개와 즐겨찾기한 실패담 10개만 우선 조회합니다.")
+    @GetMapping("/home/first-auth")
+    @Operation(summary = "로그인한 경우 홈화면 첫 로딩 API",description = "홈화면 처음 로딩 시 필요한 베스트 실패담 5개와 즐겨찾기한 실패담 10개만 우선 조회합니다.")
     public ResponseEntity<BaseResponse> getFirstPostList(@Parameter(hidden = true) @AuthenticatedUser User user) {
 
         List<PostResponse.PostPreviewListDto> result = feedService.getFirstPostList(user);
+        return BaseResponse.onSuccess(SuccessStatus._OK, result);
+    }
+
+    /**
+     * 홈화면 첫 로딩 - 로그인 X
+     */
+    @GetMapping("/home/first-guest")
+    @Operation(summary = "로그인하지 않은 경우 홈화면 첫 로딩 API",description = "홈화면 처음 로딩 시 필요한 베스트 실패담 5개를 조회합니다. 즐찾 리스트는 null ")
+    public ResponseEntity<BaseResponse> getFirstPostList() {
+
+        List<PostResponse.PostPreviewListDto> result = feedService.getFirstPostListForGuest();
         return BaseResponse.onSuccess(SuccessStatus._OK, result);
     }
 

--- a/src/main/java/Oops/backend/domain/post/service/HomeFeedService.java
+++ b/src/main/java/Oops/backend/domain/post/service/HomeFeedService.java
@@ -10,4 +10,5 @@ public interface HomeFeedService {
     List<PostResponse.PostPreviewListDto> getFirstPostList(User user);
     PostResponse.PostPreviewListDto getLaterPostList();
     PostResponse.PostPreviewListDto searchPosts(String keyword, Pageable pageable);
+    List<PostResponse.PostPreviewListDto> getFirstPostListForGuest();
 }

--- a/src/main/java/Oops/backend/domain/post/service/HomeFeedServiceImpl.java
+++ b/src/main/java/Oops/backend/domain/post/service/HomeFeedServiceImpl.java
@@ -30,7 +30,7 @@ public class HomeFeedServiceImpl implements HomeFeedService {
     private final CategoryRepository categoryRepository;
 
     /**
-     * 홈화면 첫로딩
+     * 홈화면 첫로딩 - 로그인 사용자
      */
     @Override
     @Transactional(readOnly = true)
@@ -39,20 +39,8 @@ public class HomeFeedServiceImpl implements HomeFeedService {
         List<PostResponse.PostPreviewListDto> result = new ArrayList<>();
 
         // 1. 전날 23:59까지 작성된 글 중 베스트 실패담 5개 조회
-        LocalDateTime cutoff = LocalDate.now().atStartOfDay().minusSeconds(1);
-        List<Post> bestPosts = homeFeedRepository.findTopBestPostBefore(cutoff, PageRequest.of(0, 5));
-
-        List<PostResponse.PostPreviewDto> bestPreviewDtos = bestPosts.stream()
-                .map(PostResponse.PostPreviewDto::from)
-                .collect(Collectors.toList());
-
-        PostResponse.PostPreviewListDto bestListDto = PostResponse.PostPreviewListDto.builder()
-                .name("베스트 Failers")
-                .posts(bestPreviewDtos)
-                .isLast(true)
-                .build();
-
-        result.add(bestListDto); // 항상 베스트 리스트는 추가
+        PostResponse.PostPreviewListDto bestListDto = convertBestListDto();
+        result.add(bestListDto);
 
         // 2. 즐겨찾기한 카테고리의 최신 글 10개 조회
         List<UserAndCategory> userCategories = userAndCategoryRepository.findByUserId(user.getId());
@@ -86,6 +74,51 @@ public class HomeFeedServiceImpl implements HomeFeedService {
         result.add(markedListDto);
 
         return result;
+    }
+
+    /**
+     * 홈화면 첫로딩 - 게스트 이용자
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public List<PostResponse.PostPreviewListDto> getFirstPostListForGuest() {
+
+        List<PostResponse.PostPreviewListDto> result = new ArrayList<>();
+
+        // 1. 전날 23:59까지 작성된 글 중 베스트 실패담 5개 조회
+        PostResponse.PostPreviewListDto bestListDto = convertBestListDto();
+        result.add(bestListDto);
+
+        // 2. 즐겨찾기 부분은 null
+        result.add(
+                PostResponse.PostPreviewListDto.builder()
+                        .name("즐겨찾기한 카테고리")
+                        .posts(Collections.emptyList())
+                        .isLast(true)
+                        .build()
+        );
+
+        return result;
+    }
+
+    /**
+     * 베스트 실패담 조회 및 dto 변환
+     */
+    private PostResponse.PostPreviewListDto convertBestListDto(){
+        LocalDateTime cutoff = LocalDate.now().atStartOfDay().minusSeconds(1);
+        List<Post> bestPosts = homeFeedRepository.findTopBestPostBefore(cutoff, PageRequest.of(0, 5));
+
+        List<PostResponse.PostPreviewDto> bestPreviewDtos = bestPosts.stream()
+                .map(PostResponse.PostPreviewDto::from)
+                .collect(Collectors.toList());
+
+        PostResponse.PostPreviewListDto bestListDto = PostResponse.PostPreviewListDto.builder()
+                .name("베스트 Failers")
+                .posts(bestPreviewDtos)
+                .isLast(true)
+                .build();
+
+        return bestListDto;
     }
 
     /**

--- a/src/main/java/Oops/backend/domain/randomTopic/Service/RandomTopicSchedulerImpl.java
+++ b/src/main/java/Oops/backend/domain/randomTopic/Service/RandomTopicSchedulerImpl.java
@@ -13,14 +13,16 @@ public class RandomTopicSchedulerImpl {
     private final RandomTopicRepository randomTopicRepository;
 
     @Scheduled(cron = "0 0 0 * * MON") // 매주 월요일 00시
+    //@Scheduled(cron = "0 * * * * *") // 디버깅용 - 매 분 0초에 실행
     @Transactional
     public void updateWeeklyTopic() {
-        // 1. 모든 주제 초기화
-        randomTopicRepository.resetAllCurrent();
 
-        // 2. 현재 isCurrent == 1인 주제 찾기
+        // 1. 현재 isCurrent == 1인 주제 찾기
         RandomTopic current = randomTopicRepository.findCurrentTopic()
                 .orElseThrow(() -> new IllegalStateException("현재 주제가 설정되어 있지 않습니다."));
+
+        // 2. 모든 주제 초기화
+        randomTopicRepository.resetAllCurrent();
 
         // 3. 다음 주제 선택
         RandomTopic next = current.getNextRandomTopic();

--- a/src/main/java/Oops/backend/domain/randomTopic/Service/RandomTopicServiceImpl.java
+++ b/src/main/java/Oops/backend/domain/randomTopic/Service/RandomTopicServiceImpl.java
@@ -3,7 +3,6 @@ package Oops.backend.domain.randomTopic.Service;
 import Oops.backend.common.exception.GeneralException;
 import Oops.backend.common.status.ErrorStatus;
 import Oops.backend.domain.post.entity.Post;
-import Oops.backend.domain.post.repository.PostRepository;
 import Oops.backend.domain.post.repository.SpecFeedRepository;
 import Oops.backend.domain.randomTopic.Repository.RandomTopicRepository;
 import Oops.backend.domain.randomTopic.dto.RandomTopicResponse;
@@ -23,7 +22,6 @@ import java.time.LocalDateTime;
 public class RandomTopicServiceImpl implements RandomTopicService {
 
     private final RandomTopicRepository randomTopicRepository;
-    private final SpecFeedRepository SpecFeedRepository;
 
     @Override
     @Transactional(readOnly = true)
@@ -35,7 +33,7 @@ public class RandomTopicServiceImpl implements RandomTopicService {
 
         // 이번주 주제 dto 변환
         RandomTopicResponse.TopicInfoDto currentTopicInfoDto = RandomTopicResponse.TopicInfoDto.builder()
-                .informNum(2)
+                .informNum(1)
                 .topicId(currentTopic.getId())
                 .topicName(currentTopic.getName())
                 .topicIcon(currentTopic.getImage())
@@ -43,22 +41,17 @@ public class RandomTopicServiceImpl implements RandomTopicService {
 
         // 저번주 랜덤 주제 조회
         RandomTopic lastTopic = currentTopic.getLastRandomTopic();
-        Long lastTopicId = lastTopic.getId();
 
         // 저번주 주제 dto 변환
         RandomTopicResponse.TopicInfoDto lastTopicInfoDto = RandomTopicResponse.TopicInfoDto.builder()
-                .informNum(1)
+                .informNum(2)
                 .topicId(lastTopic.getId())
                 .topicName(lastTopic.getName())
                 .topicIcon(lastTopic.getImage())
                 .build();
 
         // 사용자가 저번주 주제에 대하여 인기글에 선정되었는지 여부
-        LocalDateTime cutoff = LocalDate.now().atStartOfDay().minusSeconds(1);
-        Page<Post> bestPosts = SpecFeedRepository.findTop3BestPostsByTopic(lastTopicId, cutoff, PageRequest.of(0, 3));
-
-        boolean isBestUser = bestPosts.stream()
-                .anyMatch(post -> post.getUser().getId().equals(user.getId()));
+        Boolean isBestUser = user.getIsSelected();
 
         // 결과 반환
         return RandomTopicResponse.BannarsInfoDto.builder()

--- a/src/main/java/Oops/backend/domain/randomTopic/entity/RandomTopic.java
+++ b/src/main/java/Oops/backend/domain/randomTopic/entity/RandomTopic.java
@@ -3,7 +3,6 @@ package Oops.backend.domain.randomTopic.entity;
 import Oops.backend.domain.common.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
-import java.time.LocalDate;
 
 @Entity
 @Getter
@@ -27,5 +26,5 @@ public class RandomTopic extends BaseEntity {
     private String image;
 
     @Column(nullable = false)
-    private Integer isCurrent;
+    private Integer isCurrent = 0;
 }

--- a/src/main/java/Oops/backend/domain/user/entity/User.java
+++ b/src/main/java/Oops/backend/domain/user/entity/User.java
@@ -30,11 +30,17 @@ public class User extends BaseEntity {
     @Column
     private Integer report;
 
+    @Column
+    @Builder.Default
+    private Boolean isSelected = false;
+
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
     private List<UserLastLuckyDraw> lastLuckyDraws = new ArrayList<>();
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
     @Column
+    @Builder.Default
     private List<UserTag> tags = new ArrayList<>();
 
 }

--- a/src/main/java/Oops/backend/domain/user/service/UserScheduler.java
+++ b/src/main/java/Oops/backend/domain/user/service/UserScheduler.java
@@ -1,0 +1,72 @@
+package Oops.backend.domain.user.service;
+
+import Oops.backend.common.exception.GeneralException;
+import Oops.backend.common.status.ErrorStatus;
+import Oops.backend.domain.auth.AuthenticatedUser;
+import Oops.backend.domain.post.entity.Post;
+import Oops.backend.domain.post.repository.SpecFeedRepository;
+import Oops.backend.domain.randomTopic.Repository.RandomTopicRepository;
+import Oops.backend.domain.randomTopic.entity.RandomTopic;
+import Oops.backend.domain.user.entity.User;
+import Oops.backend.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class UserScheduler {
+    private final SpecFeedRepository specFeedRepository;
+    private final RandomTopicRepository randomTopicRepository;
+    private final UserRepository userRepository;
+
+    @Scheduled(cron = "0 0 0 * * MON") // 매주 월요일 00시
+    //@Scheduled(cron = "0 * * * * *") // 디버깅용 - 매 분 0초에 실행
+    @Transactional
+    public void updateWeeklyUserPoint() {
+
+        // 이번주 랜덤 주제 조회
+        RandomTopic currentTopic = randomTopicRepository.findCurrentTopic()
+                .orElseThrow(() -> new GeneralException(ErrorStatus._INTERNAL_SERVER_ERROR));
+
+        // 저번주 랜덤 주제 조회
+        RandomTopic lastTopic = currentTopic.getLastRandomTopic();
+        Long lastTopicId = lastTopic.getId();
+
+        // 해당 사용자 저번주 인기글 선정 여부 확인
+        LocalDateTime cutoff = LocalDate.now().atStartOfDay().minusSeconds(1);
+
+        List<Post> bestPosts = specFeedRepository
+                .findTop3BestPostsByTopic(lastTopicId, cutoff, PageRequest.of(0, 3))
+                .getContent();
+
+        // 사용자별 count 집계
+        Map<Long, Long> postCountByUserId = bestPosts.stream()
+                .collect(Collectors.groupingBy(
+                        post -> post.getUser().getId(),
+                        Collectors.counting()
+                ));
+
+        // 포인트 지급 (1건당 50점)
+        for (Map.Entry<Long, Long> entry : postCountByUserId.entrySet()) {
+            Long userId = entry.getKey();
+            Long count = entry.getValue();
+
+            userRepository.findById(userId).ifPresent(user -> {
+                int newPoint = user.getPoint() + (int)(count * 50);
+                user.setPoint(newPoint);
+                user.setIsSelected(true);
+                userRepository.save(user);
+            });
+        }
+    }
+}


### PR DESCRIPTION
## #⃣ 연관된 이슈

> #139 

## 📝 작업 내용

> 기존에 로그인한 경우에만 홈화면 조회가 가능했는데 로그인 여부와 상관 없이 홈화면을 보여주도록 API를 분리함 
로그인한 경우에는 베스트 실패담과 즐겨찾기한 실패담 모두 조회 가능 
로그인하지 않은 경우에는 베스트 실패담만 조회 가능 