### PR TITLE
🐛 [BUG] #141, 142 : 스웨거 환경에서의 로그인 오류 및 교훈 관련 API에서 게시글 Id가 전달되지 않은 문제

### DIFF
--- a/src/main/java/Oops/backend/config/WebConfig.java
+++ b/src/main/java/Oops/backend/config/WebConfig.java
@@ -24,7 +24,7 @@ public class WebConfig implements WebMvcConfigurer {
         registry.addMapping("/**")
                 .allowedOriginPatterns(
                         "http://localhost:5173",
-                        "http://15.164.217.202:8080/swagger-ui/index.html#/"
+                        "http://15.164.217.202:8080"
                 )
                 .allowedMethods("GET", "POST", "PUT", "DELETE", "PATCH")
                 .allowedHeaders("*")

--- a/src/main/java/Oops/backend/domain/auth/service/AuthService.java
+++ b/src/main/java/Oops/backend/domain/auth/service/AuthService.java
@@ -76,7 +76,7 @@ public class AuthService {
                 .maxAge(Duration.ofMillis(1800000))
                 .httpOnly(true)
                 .sameSite("None")
-                .secure(false)
+                .secure(true)
                 .path("/")
                 .build();
         response.addHeader("Set-Cookie", cookie.toString());

--- a/src/main/java/Oops/backend/domain/lesson/controller/LessonController.java
+++ b/src/main/java/Oops/backend/domain/lesson/controller/LessonController.java
@@ -29,7 +29,7 @@ public class LessonController {
     @Operation(summary = "교훈 작성 API")
     @PostMapping
     public ResponseEntity<BaseResponse> createLesson(@AuthenticatedUser User user,
-                                                    Long postId,
+                                                    @PathVariable Long postId,
                                                     @Valid @RequestBody CreateLessonRequest request){
 
         log.info("Post /api/posts/lessons 호출, User = {}", user.getUserName());
@@ -42,7 +42,7 @@ public class LessonController {
     @Operation(summary = "교훈 조회 API")
     @GetMapping
     public ResponseEntity<BaseResponse> getLesson(@AuthenticatedUser User user,
-                                                  Long postId){
+                                                  @PathVariable Long postId){
 
         log.info("Get /api/posts/lessons 호출, User = {}", user.getUserName());
 


### PR DESCRIPTION
`close #{이슈 번호}`을 사용하면 PR이 merge되면 해당 이슈가 자동으로 닫힙니다.

## #⃣ 연관된 이슈

> ex) close #141 , close #142 

## 📝 작업 내용

> AuthService에서 secure(true)로 설정
> WebConfig에서 스웨거 출처 양식 수정
> Lesson에서 postId를 받을 때 ```@PathVariable``` 어노테이션 추가