### PR TITLE
✨[FEAT] #168 게시글의 댓글 목록만 조회하는 API 구현/조회수, 좋아요 동시성 문제 수정

### DIFF
--- a/src/main/java/Oops/backend/common/status/ErrorStatus.java
+++ b/src/main/java/Oops/backend/common/status/ErrorStatus.java
@@ -41,10 +41,12 @@ public enum ErrorStatus {
     NO_POST(HttpStatus.NOT_FOUND, "POST404", "게시물이 존재하지 않습니다."),
     INVALID_POST_CONTEXT(HttpStatus.BAD_REQUEST, "POST400", "추천 기준이 되는 category나 topic이 없습니다."),
     UNAUTHORIZED_FOR_POST(HttpStatus.UNAUTHORIZED, "POST401", "게시글 삭제 권한이 없습니다."),
+    ALREADY_LIKED_POST(HttpStatus.BAD_REQUEST, "POST405", "이미 응원한 게시글입니다."),
 
     // 댓글 관련 에러
     COMMENT_NOT_FOUND(HttpStatus.BAD_REQUEST, "COMMENT400", "존재하지 않는 댓글입니다."),
     UNAUTHORIZED_FOR_COMMENT(HttpStatus.UNAUTHORIZED, "COMMENT401", "댓글 삭제 권한이 없습니다."),
+    ALREADY_LIKED_COMMENT(HttpStatus.BAD_REQUEST, "COMMENT405", "이미 공감한 댓글입니다."),
 
     // 행운부적 관련 에러
     NO_LUCKY_DRAW(HttpStatus.INTERNAL_SERVER_ERROR, "LUCKYDRAW500", "행운부적이 존재하지 않습니다."),

--- a/src/main/java/Oops/backend/domain/comment/controller/CommentRestController.java
+++ b/src/main/java/Oops/backend/domain/comment/controller/CommentRestController.java
@@ -5,6 +5,7 @@ import Oops.backend.common.status.SuccessStatus;
 import Oops.backend.domain.auth.AuthenticatedUser;
 import Oops.backend.domain.comment.dto.CommentRequestDto;
 import Oops.backend.domain.comment.service.CommentCommandService;
+import Oops.backend.domain.comment.service.CommentQueryService;
 import Oops.backend.domain.user.entity.User;
 import jakarta.validation.Valid;
 import io.swagger.v3.oas.annotations.Operation;
@@ -22,6 +23,7 @@ import org.springframework.web.bind.annotation.*;
 public class CommentRestController {
 
     private final CommentCommandService commentCommandService;
+    private final CommentQueryService commentQueryService;
 
     @Operation(summary = "댓글 달기")
     @PostMapping("/posts/{postId}/comments")
@@ -54,11 +56,20 @@ public class CommentRestController {
     public ResponseEntity<BaseResponse> cheerComment(@PathVariable Long commentId,
                                                      @AuthenticatedUser User user){
 
-        log.info("Post /api//comments/{commentId}/cheers 호출, User = {}", user.getUserName());
+        log.info("Post /api/comments/{commentId}/cheers 호출, User = {}", user.getUserName());
 
         commentCommandService.cheerComment(commentId, user);
 
         return BaseResponse.onSuccess(SuccessStatus._OK);
     }
+
+    @Operation(summary = "게시글에 대한 댓글 조회")
+    @GetMapping("/post/{postId}/comments")
+    public ResponseEntity<BaseResponse> getCommentsOfPost(@PathVariable Long postId,
+                                                          @AuthenticatedUser User user){
+
+        return BaseResponse.onSuccess(SuccessStatus._OK, commentQueryService.findCommentsOfPost(postId, user));
+    }
+
 
 }

--- a/src/main/java/Oops/backend/domain/comment/entity/Comment.java
+++ b/src/main/java/Oops/backend/domain/comment/entity/Comment.java
@@ -69,12 +69,4 @@ public class Comment extends BaseEntity {
         comment.setParent(this);
     }
 
-    public void plusCheer(){
-        this.likes++;
-    }
-
-    public void minusCheer(){
-        this.likes--;
-    }
-
 }

--- a/src/main/java/Oops/backend/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/Oops/backend/domain/comment/repository/CommentRepository.java
@@ -2,8 +2,19 @@ package Oops.backend.domain.comment.repository;
 
 import Oops.backend.domain.comment.entity.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+    @Modifying
+    @Query("update Comment c set c.likes = c.likes+1 where c.id = :commentId")
+    public void plusCommentLikes(@Param("commentId") Long commentId);
+
+    @Modifying
+    @Query("update Comment c set c.likes = c.likes-1 where c.id = :commentId")
+    public void minusCommentLikes(@Param("commentId") Long commentId);
 
 
 }

--- a/src/main/java/Oops/backend/domain/comment/service/CommentQueryService.java
+++ b/src/main/java/Oops/backend/domain/comment/service/CommentQueryService.java
@@ -1,0 +1,43 @@
+package Oops.backend.domain.comment.service;
+
+import Oops.backend.common.exception.GeneralException;
+import Oops.backend.common.status.ErrorStatus;
+import Oops.backend.domain.comment.dto.CommentResponse;
+import Oops.backend.domain.comment.entity.Comment;
+import Oops.backend.domain.comment.repository.CommentRepository;
+import Oops.backend.domain.post.entity.Post;
+import Oops.backend.domain.post.service.PostQueryService;
+import Oops.backend.domain.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class CommentQueryService {
+
+    private final CommentRepository commentRepository;
+    private final PostQueryService postQueryService;
+
+    public Comment findComment(Long commentId){
+
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.COMMENT_NOT_FOUND));
+
+        return comment;
+    }
+
+    public List<CommentResponse> findCommentsOfPost(Long postId, User user){
+
+        Post post = postQueryService.findPost(postId);
+
+        List<CommentResponse> Comments = post.getComments().stream()
+                .map(CommentResponse::from)
+                .toList();
+
+        return Comments;
+    }
+
+
+}

--- a/src/main/java/Oops/backend/domain/commentReport/controller/CommentReportController.java
+++ b/src/main/java/Oops/backend/domain/commentReport/controller/CommentReportController.java
@@ -1,0 +1,38 @@
+package Oops.backend.domain.commentReport.controller;
+
+import Oops.backend.common.response.BaseResponse;
+import Oops.backend.common.status.SuccessStatus;
+import Oops.backend.domain.auth.AuthenticatedUser;
+import Oops.backend.domain.commentReport.dto.CommentReportRequest;
+import Oops.backend.domain.commentReport.service.CommentReportService;
+import Oops.backend.domain.user.entity.User;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api")
+@Slf4j
+@RequiredArgsConstructor
+@Tag(name = "댓글 신고 API")
+public class CommentReportController {
+
+    private final CommentReportService commentReportService;
+
+    @Operation(summary = "댓글 신고하기")
+    @PostMapping("/comments/{commentId}/reports")
+    public ResponseEntity<BaseResponse> reportComment(@PathVariable Long commentId,
+                                                     @AuthenticatedUser User user,
+                                                     @RequestBody CommentReportRequest request){
+
+        log.info("Post /api/comments/{commentId}/reports 호출, User = {}", user.getUserName());
+
+        commentReportService.reportComment(commentId, user, request);
+
+        return BaseResponse.onSuccess(SuccessStatus._OK);
+    }
+
+}

--- a/src/main/java/Oops/backend/domain/commentReport/dto/CommentReportRequest.java
+++ b/src/main/java/Oops/backend/domain/commentReport/dto/CommentReportRequest.java
@@ -1,0 +1,12 @@
+package Oops.backend.domain.commentReport.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class CommentReportRequest {
+
+    String content;
+
+}

--- a/src/main/java/Oops/backend/domain/commentReport/entity/CommentReport.java
+++ b/src/main/java/Oops/backend/domain/commentReport/entity/CommentReport.java
@@ -8,9 +8,7 @@ import lombok.*;
 
 @Entity
 @Getter
-@Setter
-@NoArgsConstructor
-@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CommentReport extends BaseEntity{
 
     @OneToOne(fetch = FetchType.LAZY)
@@ -21,6 +19,22 @@ public class CommentReport extends BaseEntity{
     @JoinColumn(name = "target")
     private Comment comment;
 
-    @Column
-    private String reason;
+    @Column(nullable = false, length = 300)
+    private String content;
+
+    @Builder
+    private CommentReport(User reportUser, Comment comment, String content){
+        this.reportUser = reportUser;
+        this.comment = comment;
+        this.content = content;
+    }
+
+    public static CommentReport of(User reportUser, Comment comment, String content){
+        return CommentReport.builder()
+                .reportUser(reportUser)
+                .comment(comment)
+                .content(content)
+                .build();
+    }
+
 }

--- a/src/main/java/Oops/backend/domain/commentReport/service/CommentReportService.java
+++ b/src/main/java/Oops/backend/domain/commentReport/service/CommentReportService.java
@@ -1,0 +1,31 @@
+package Oops.backend.domain.commentReport.service;
+
+import Oops.backend.domain.comment.entity.Comment;
+import Oops.backend.domain.comment.service.CommentQueryService;
+import Oops.backend.domain.commentReport.dto.CommentReportRequest;
+import Oops.backend.domain.commentReport.entity.CommentReport;
+import Oops.backend.domain.commentReport.repository.CommentReportRepository;
+import Oops.backend.domain.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CommentReportService {
+
+    private final CommentQueryService commentQueryService;
+    private final CommentReportRepository commentReportRepository;
+
+    @Transactional
+    public void reportComment(Long commentId, User user, CommentReportRequest request){
+
+        Comment comment = commentQueryService.findComment(commentId);
+
+        CommentReport newCommentReport = CommentReport.of(user, comment, request.getContent());
+
+        commentReportRepository.save(newCommentReport);
+    }
+
+
+}

--- a/src/main/java/Oops/backend/domain/post/controller/PostRestController.java
+++ b/src/main/java/Oops/backend/domain/post/controller/PostRestController.java
@@ -50,7 +50,7 @@ public class PostRestController {
 
         log.info("Post /api/posts/{postId}/cheers 호출, User = {}", user.getUserName());
 
-        postCommandService.cheerPost(postId, user);
+        postCommandService.likePost(postId, user);
         return BaseResponse.onSuccess(SuccessStatus._OK);
     }
 

--- a/src/main/java/Oops/backend/domain/post/dto/PostReportRequest.java
+++ b/src/main/java/Oops/backend/domain/post/dto/PostReportRequest.java
@@ -1,0 +1,11 @@
+package Oops.backend.domain.post.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class PostReportRequest {
+
+    String content;
+}

--- a/src/main/java/Oops/backend/domain/post/entity/Post.java
+++ b/src/main/java/Oops/backend/domain/post/entity/Post.java
@@ -78,13 +78,5 @@ public class Post extends BaseEntity {
     private Post previousPost;
     */
 
-    public void plusCheer(){
-        this.likes++;
-    }
-
-    public void minusCheer(){
-        this.likes--;
-    }
-
 }
 

--- a/src/main/java/Oops/backend/domain/post/repository/PostRepository.java
+++ b/src/main/java/Oops/backend/domain/post/repository/PostRepository.java
@@ -7,6 +7,7 @@ import Oops.backend.domain.postGroup.entity.PostGroup;
 import Oops.backend.domain.user.entity.User;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -36,5 +37,19 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     //situation
     List<Post> findByUserAndSituation(User user, Situation situation);
+
+    @Modifying
+    @Query("UPDATE Post p SET p.likes = p.likes+1 WHERE p.id = :postId")
+    void plusPostLikes(@Param("postId") Long postId);
+
+    @Modifying
+    @Query("UPDATE Post p SET p.likes = p.likes-1 WHERE p.id = :postId")
+    void minusPostLikes(@Param("postId") Long postId);
+
+    @Modifying
+    @Query("update Post p set p.watching = p.watching+1 where p.id = :postId")
+    void plusPostWatching(@Param("postId") Long postId);
+
 }
+
 

--- a/src/main/java/Oops/backend/domain/post/service/PostCommandService.java
+++ b/src/main/java/Oops/backend/domain/post/service/PostCommandService.java
@@ -9,8 +9,9 @@ import java.util.List;
 
 public interface PostCommandService {
 
-    void cheerPost(Long postId, User user);
+    void likePost(Long postId, User user);
     void deletePost(Long postId, User user);
+    void watchPost(Long postId);
 
     //PostCreateResponse createPost(User user, PostCreateRequest request);
     PostCreateResponse createPost(User user, PostCreateRequest request ,List<MultipartFile> imageFiles);

--- a/src/main/java/Oops/backend/domain/post/service/PostQueryServiceImpl.java
+++ b/src/main/java/Oops/backend/domain/post/service/PostQueryServiceImpl.java
@@ -26,7 +26,7 @@ public class PostQueryServiceImpl implements PostQueryService{
     public Post findPost(Long postId) {
 
         Post post = postRepository.findById(postId)
-                .orElseThrow(() -> new GeneralException(ErrorStatus._BAD_REQUEST, "존재하지 않는 게시글입니다."));
+                .orElseThrow(() -> new GeneralException(ErrorStatus.NO_POST));
 
         return post;
     }

--- a/src/main/java/Oops/backend/domain/postGroup/service/PostGroupQueryServiceImpl.java
+++ b/src/main/java/Oops/backend/domain/postGroup/service/PostGroupQueryServiceImpl.java
@@ -9,6 +9,7 @@ import Oops.backend.domain.category.service.CategoryService;
 import Oops.backend.domain.post.dto.PostResponse;
 import Oops.backend.domain.post.entity.Post;
 import Oops.backend.domain.post.model.Situation;
+import Oops.backend.domain.post.service.PostCommandService;
 import Oops.backend.domain.post.service.PostQueryService;
 import Oops.backend.domain.postGroup.dto.GetPostGroupResponse;
 import Oops.backend.domain.postGroup.entity.PostGroup;
@@ -22,6 +23,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class PostGroupQueryServiceImpl implements PostGroupQueryService {
 
     private final PostQueryService postQueryService;
+    private final PostCommandService postCommandService;
 
     @Override
     @Transactional
@@ -39,6 +41,9 @@ public class PostGroupQueryServiceImpl implements PostGroupQueryService {
         // 카테고리 DTO 생성
         CategoryResponse.CategoryResponseDto categoryResponseDto
                 = CategoryResponse.CategoryResponseDto.from(postGroup.getCategory());
+
+        // 조회한 게시글 조회수 +1
+        postCommandService.watchPost(postId);
 
         // 3개의 게시글 DTO 초기화
         PostResponse.PostViewDto postViewDtoFailure = null;

--- a/src/main/java/Oops/backend/domain/postReport/controller/PostReportController.java
+++ b/src/main/java/Oops/backend/domain/postReport/controller/PostReportController.java
@@ -1,0 +1,40 @@
+package Oops.backend.domain.postReport.controller;
+
+import Oops.backend.common.response.BaseResponse;
+import Oops.backend.common.status.SuccessStatus;
+import Oops.backend.domain.auth.AuthenticatedUser;
+import Oops.backend.domain.post.dto.PostReportRequest;
+import Oops.backend.domain.postReport.service.PostReportService;
+import Oops.backend.domain.user.entity.User;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+@RequestMapping("/api/posts")
+@Tag(name = "게시글 신고 API")
+public class PostReportController {
+
+    private final PostReportService postReportService;
+
+    // 실패담 신고
+    @Operation(summary = "게시글 신고하기")
+    @PostMapping("/{postId}/reports")
+    public ResponseEntity<BaseResponse> reportPost(@AuthenticatedUser User user,
+                                                   @PathVariable Long postId,
+                                                   @RequestBody PostReportRequest request){
+
+        log.info("Post /api/posts/{postId}/reports 호출, User = {}", user.getUserName());
+
+        postReportService.reportPost(postId, user, request);
+
+        return BaseResponse.onSuccess(SuccessStatus._OK);
+    }
+
+
+}

--- a/src/main/java/Oops/backend/domain/postReport/entity/PostReport.java
+++ b/src/main/java/Oops/backend/domain/postReport/entity/PostReport.java
@@ -11,8 +11,6 @@ import lombok.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PostReport extends BaseEntity {
 
-    private String reason;
-
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "reporter")
     private User user;
@@ -23,5 +21,20 @@ public class PostReport extends BaseEntity {
 
     @Column(nullable = false, length = 300)
     private String content;
+
+    @Builder
+    private PostReport(User user, Post post, String content){
+        this.user = user;
+        this.post = post;
+        this.content = content;
+    }
+
+    public static PostReport of(User user, Post post, String content){
+        return PostReport.builder()
+                .user(user)
+                .post(post)
+                .content(content)
+                .build();
+    }
 
 }

--- a/src/main/java/Oops/backend/domain/postReport/service/PostReportService.java
+++ b/src/main/java/Oops/backend/domain/postReport/service/PostReportService.java
@@ -1,0 +1,29 @@
+package Oops.backend.domain.postReport.service;
+
+import Oops.backend.domain.post.dto.PostReportRequest;
+import Oops.backend.domain.post.entity.Post;
+import Oops.backend.domain.post.service.PostQueryService;
+import Oops.backend.domain.postReport.entity.PostReport;
+import Oops.backend.domain.postReport.repository.PostReportRepository;
+import Oops.backend.domain.user.entity.User;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PostReportService {
+
+    private final PostQueryService postQueryService;
+    private final PostReportRepository postReportRepository;
+
+    @Transactional
+    public void reportPost(Long postId, User user, PostReportRequest request){
+
+        Post post = postQueryService.findPost(postId);
+
+        PostReport newPostReport = PostReport.of(user, post, request.getContent());
+
+        postReportRepository.save(newPostReport);
+    }
+}


### PR DESCRIPTION
## #⃣ 연관된 이슈

> close #168 close #169

## 📝 작업 내용

> 조회수, 좋아요 값에 대한 동시성 문제가 해결되도록 수정
> ```postId```를 통해 해당 게시글의 댓글 목록을 조회할 수 있는 API 구현