### PR TITLE
✨[FEAT]  #256 회원가입 시 약관동의 로직 추가

### DIFF
--- a/src/main/java/Oops/backend/domain/auth/AuthenticationConfig.java
+++ b/src/main/java/Oops/backend/domain/auth/AuthenticationConfig.java
@@ -24,6 +24,7 @@ public class AuthenticationConfig implements WebMvcConfigurer {
                         "/api/auth/refresh",
                         "/api/feeds/home/first-guest",
                         "/hello",
+                        "/api/terms",
                         "/health",
                         "/public/**",
                         "/swagger-ui/**",

--- a/src/main/java/Oops/backend/domain/auth/controller/AuthController.java
+++ b/src/main/java/Oops/backend/domain/auth/controller/AuthController.java
@@ -14,6 +14,7 @@ import Oops.backend.domain.user.dto.request.LoginDto;
 import Oops.backend.domain.user.entity.User;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -25,6 +26,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.aspectj.weaver.GeneratedReferenceTypeDelegate;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import Oops.backend.domain.auth.dto.request.ChangePasswordDto;
@@ -42,12 +44,72 @@ public class AuthController {
     private final AuthService authService;
     private final JwtEncoder jwtEncoder;
 
-    @Operation(summary = "회원가입", description = "새로운 사용자를 등록합니다.")
-    @ApiResponse(responseCode = "201", description = "회원가입 성공", content = @Content(schema = @Schema(implementation = BaseResponse.class)))
+    @Operation(
+            summary = "회원가입",
+            description = "새로운 사용자를 등록합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "201",
+                    description = "회원가입 성공",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = BaseResponse.class),
+                            examples = @ExampleObject(
+                                    name = "success",
+                                    value = "{\n" +
+                                            "  \"isSuccess\": true,\n" +
+                                            "  \"code\": \"COMMON201\",\n" +
+                                            "  \"message\": \"SUCCESS!\"\n" +
+                                            "}"
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "필수 약관 미동의 등으로 실패",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = BaseResponse.class),
+                            examples = @ExampleObject(
+                                    name = "required_terms_not_agreed",
+                                    value = "{\n" +
+                                            "  \"isSuccess\": false,\n" +
+                                            "  \"code\": \"COMMON400\",\n" +
+                                            "  \"message\": \"필수 약관 미동의: [1]\"\n" +
+                                            "}"
+                            )
+                    )
+            )
+    })
     @PostMapping("/join")
     public ResponseEntity<BaseResponse> join(
-            @Valid @RequestBody JoinDto joinDto,
-            HttpServletResponse response) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "회원가입 요청 바디",
+                    required = true,
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = JoinDto.class),
+                            examples = {
+                                    @ExampleObject(
+                                            name = "join_request_example",
+                                            value = "{\n" +
+                                                    "  \"email\": \"test1@example.com\",\n" +
+                                                    "  \"userName\": \"홍길동\",\n" +
+                                                    "  \"password\": \"1234abcd!\",\n" +
+                                                    "  \"termsAgreement\": [\n" +
+                                                    "    { \"termId\": 1, \"agreed\": true },\n" +
+                                                    "    { \"termId\": 2, \"agreed\": true },\n" +
+                                                    "    { \"termId\": 3, \"agreed\": true }\n" +
+                                                    "  ]\n" +
+                                                    "}"
+                                    )
+                            }
+                    )
+            )
+            @Valid @org.springframework.web.bind.annotation.RequestBody  JoinDto joinDto,
+            HttpServletResponse response
+    ) {
         this.authService.join(joinDto);
         return BaseResponse.onSuccess(SuccessStatus._CREATED);
     }

--- a/src/main/java/Oops/backend/domain/auth/dto/request/AgreeToTermDto.java
+++ b/src/main/java/Oops/backend/domain/auth/dto/request/AgreeToTermDto.java
@@ -1,0 +1,14 @@
+package Oops.backend.domain.auth.dto.request;
+
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.NotBlank;
+
+import java.util.UUID;
+
+public class AgreeToTermDto {
+    @NotBlank(message = "약관 id가 비었습니다.")
+    private UUID termId;
+
+    @AssertTrue
+    private boolean agreed;
+}

--- a/src/main/java/Oops/backend/domain/auth/dto/request/AgreeToTermDto.java
+++ b/src/main/java/Oops/backend/domain/auth/dto/request/AgreeToTermDto.java
@@ -2,13 +2,16 @@ package Oops.backend.domain.auth.dto.request;
 
 import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
 
 import java.util.UUID;
 
+@Getter
 public class AgreeToTermDto {
-    @NotBlank(message = "약관 id가 비었습니다.")
-    private UUID termId;
+    @NotNull(message = "약관 id가 비었습니다.")
+    private Long termId;
 
-    @AssertTrue
+    @NotNull(message = "동의 여부가 비었습니다.")
     private boolean agreed;
 }

--- a/src/main/java/Oops/backend/domain/auth/dto/request/JoinDto.java
+++ b/src/main/java/Oops/backend/domain/auth/dto/request/JoinDto.java
@@ -17,7 +17,7 @@ public class JoinDto {
 
     @Schema(description = "사용자 이메일", example = "test@example.com")
     @NotBlank(message = "이메일이 비었습니다.")
-    @Pattern(regexp = "^[A-Za-z0-9]+@[A-Za-z0-9]+\\.[A-Za-z]{2,6}$", message = "이메일 형식이 맞지 않습니다.")
+    @jakarta.validation.constraints.Email(message = "이메일 형식이 맞지 않습니다.")
     private String email;
 
     @Schema(description = "사용자 닉네임", example = "홍길동")
@@ -25,11 +25,11 @@ public class JoinDto {
     private String userName;
 
     @Schema(description = "사용자 비밀번호", example = "1234abcd!")
-    @NotBlank(message = "비밀번호기 비어있습니다.")
+    @NotBlank(message = "비밀번호가 비어있습니다.")
     private String password;
-
 
     @Schema(description = "사용자 약관 동의 목록")
     @NotNull(message = "약관 동의 정보가 필요합니다.")
+    @jakarta.validation.Valid
     private List<AgreeToTermDto> termsAgreement;
 }

--- a/src/main/java/Oops/backend/domain/auth/dto/request/JoinDto.java
+++ b/src/main/java/Oops/backend/domain/auth/dto/request/JoinDto.java
@@ -2,11 +2,14 @@ package Oops.backend.domain.auth.dto.request;
 
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import lombok.Builder;
 import lombok.Getter;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
 
 @Getter
 @Builder
@@ -24,4 +27,9 @@ public class JoinDto {
     @Schema(description = "사용자 비밀번호", example = "1234abcd!")
     @NotBlank(message = "비밀번호기 비어있습니다.")
     private String password;
+
+
+    @Schema(description = "사용자 약관 동의 목록")
+    @NotNull(message = "약관 동의 정보가 필요합니다.")
+    private List<AgreeToTermDto> termsAgreement;
 }

--- a/src/main/java/Oops/backend/domain/auth/service/AuthService.java
+++ b/src/main/java/Oops/backend/domain/auth/service/AuthService.java
@@ -8,10 +8,16 @@ import Oops.backend.common.status.ErrorStatus;
 import Oops.backend.domain.auth.dto.response.LoginResponse;
 import Oops.backend.domain.auth.dto.response.TokenResponseDto;
 import Oops.backend.domain.auth.repository.RefreshTokenRepository;
+import Oops.backend.domain.terms.entity.RequiredType;
+import Oops.backend.domain.terms.entity.Terms;
+import Oops.backend.domain.terms.entity.UserAndTerms;
+import Oops.backend.domain.terms.repository.TermsRepository;
+import Oops.backend.domain.terms.repository.UserAndTermsRepository;
 import Oops.backend.domain.user.dto.request.LoginDto;
 import Oops.backend.domain.user.entity.User;
 import Oops.backend.domain.user.repository.UserRepository;
 import jakarta.servlet.http.HttpServletResponse;
+import Oops.backend.domain.auth.dto.request.AgreeToTermDto;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
@@ -21,6 +27,11 @@ import Oops.backend.domain.auth.repository.AuthRepository;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 @Service
 @AllArgsConstructor
@@ -32,24 +43,62 @@ public class AuthService {
     private final RefreshTokenProvider refreshTokenProvider;
     private final RefreshTokenRepository refreshTokenRepository;
     private final UserRepository userRepository;
+    private final TermsRepository termsRepository;
+    private final UserAndTermsRepository userAndTermsRepository;
     /*
     회원가입
      */
+    @Transactional
     public void join(JoinDto joinDto) {
-        // 이메일이 이미 존재하는지 확인
+        // 1) 중복 이메일 체크
         this.isEmailExist(joinDto.getEmail());
-        String encryptedPassword = this.passwordHashEncryption.encrypt(joinDto.getPassword());
+        log.info("terms.count={}", termsRepository.count());
+        List<Terms> requiredTerms = termsRepository.findAllByRequired(RequiredType.REQUIRED);
+        Set<Long> requiredIds = requiredTerms.stream()
+                .map(Terms::getId)
+                .collect(Collectors.toSet());
 
-        // 이메일이 존재하지 않는다면 새로운 User 생성
+        Map<Long, Boolean> agreedMap = joinDto.getTermsAgreement().stream()
+                .collect(Collectors.toMap(AgreeToTermDto::getTermId, AgreeToTermDto::isAgreed, (a, b) -> a));
+
+        List<Long> notAgreedRequired = requiredIds.stream()
+                .filter(id -> !Boolean.TRUE.equals(agreedMap.get(id)))
+                .toList();
+
+        if (!notAgreedRequired.isEmpty()) {
+            throw new GeneralException(ErrorStatus._BAD_REQUEST,
+                    "필수 약관 미동의: " + notAgreedRequired);
+        }
+
+        // 5) 사용자 생성/저장
+        String encryptedPassword = this.passwordHashEncryption.encrypt(joinDto.getPassword());
         User user = User.builder()
                 .email(joinDto.getEmail())
                 .password(encryptedPassword)
                 .userName(joinDto.getUserName())
                 .point(0)
                 .build();
-
         authRepository.save(user);
+        log.info("requiredIds={}", requiredIds);
+        log.info("agreedMap={}", agreedMap);
+        log.info("notAgreedRequired={}", notAgreedRequired);
+        Set<Long> agreedIds = joinDto.getTermsAgreement().stream()
+                .filter(AgreeToTermDto::isAgreed)
+                .map(AgreeToTermDto::getTermId)
+                .collect(Collectors.toSet());
+
+        if (!agreedIds.isEmpty()) {
+            List<Terms> agreedTerms = StreamSupport.stream(
+                    termsRepository.findAllById(agreedIds).spliterator(), false
+            ).collect(Collectors.toList());            for (Terms t : agreedTerms) {
+                UserAndTerms map = new UserAndTerms();
+                map.setUser(user);
+                map.setTerm(t);
+                userAndTermsRepository.save(map);
+            }
+        }
     }
+
 
     /*
     Email 유일성 확인

--- a/src/main/java/Oops/backend/domain/terms/controller/TermsController.java
+++ b/src/main/java/Oops/backend/domain/terms/controller/TermsController.java
@@ -1,0 +1,29 @@
+package Oops.backend.domain.terms.controller;
+
+import Oops.backend.common.response.BaseResponse;
+import Oops.backend.common.status.SuccessStatus;
+import Oops.backend.domain.terms.dto.response.TermsResponse;
+import Oops.backend.domain.terms.service.TermsService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "약관 API")
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class TermsController {
+
+    private final TermsService termsService;
+
+    @Operation(summary = "이용약관 전체 조회", description = "3개의 이용약관(필수/선택 포함)을 반환합니다.")
+    @GetMapping("/terms")
+    public ResponseEntity<BaseResponse> getTerms() {
+        List<TermsResponse> terms = termsService.getAllTerms();
+        return BaseResponse.onSuccess(SuccessStatus._OK, terms);
+    }
+}

--- a/src/main/java/Oops/backend/domain/terms/dto/response/TermsResponse.java
+++ b/src/main/java/Oops/backend/domain/terms/dto/response/TermsResponse.java
@@ -1,2 +1,15 @@
-package Oops.backend.domain.terms.dto.response;public class TermsResponse {
+package Oops.backend.domain.terms.dto.response;
+
+import Oops.backend.domain.terms.entity.RequiredType;
+import Oops.backend.domain.terms.entity.Terms;
+
+public record TermsResponse(
+        Long id,
+        String title,
+        String content,
+        RequiredType required
+) {
+    public static TermsResponse from(Terms t) {
+        return new TermsResponse(t.getId(), t.getTitle(), t.getContent(), t.getRequired());
+    }
 }

--- a/src/main/java/Oops/backend/domain/terms/dto/response/TermsResponse.java
+++ b/src/main/java/Oops/backend/domain/terms/dto/response/TermsResponse.java
@@ -1,0 +1,2 @@
+package Oops.backend.domain.terms.dto.response;public class TermsResponse {
+}

--- a/src/main/java/Oops/backend/domain/terms/entity/RequiredType.java
+++ b/src/main/java/Oops/backend/domain/terms/entity/RequiredType.java
@@ -1,0 +1,7 @@
+package Oops.backend.domain.terms.entity;
+
+public enum RequiredType {
+    REQUIRED,
+    OPTIONAL
+}
+

--- a/src/main/java/Oops/backend/domain/terms/entity/Terms.java
+++ b/src/main/java/Oops/backend/domain/terms/entity/Terms.java
@@ -17,6 +17,15 @@ public class Terms extends BaseEntity {
     @Column
     private String content;
 
-    @Column
-    private String required;
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private RequiredType required;
+
+    public RequiredType getRequired() {
+        return required;
+    }
+
+    public void setRequired(RequiredType required) {
+        this.required = required;
+    }
 }

--- a/src/main/java/Oops/backend/domain/terms/entity/Terms.java
+++ b/src/main/java/Oops/backend/domain/terms/entity/Terms.java
@@ -14,7 +14,8 @@ public class Terms extends BaseEntity {
     @Column
     private String title;
 
-    @Column
+    @Lob
+    @Column(columnDefinition = "LONGTEXT")
     private String content;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/Oops/backend/domain/terms/repository/TermsRepository.java
+++ b/src/main/java/Oops/backend/domain/terms/repository/TermsRepository.java
@@ -8,5 +8,5 @@ import java.util.List;
 
 public interface TermsRepository extends CrudRepository<Terms, Long> {
     List<Terms> findAllByRequired(RequiredType required);
-
+    List<Terms> findAllByOrderByIdAsc();
 }

--- a/src/main/java/Oops/backend/domain/terms/repository/TermsRepository.java
+++ b/src/main/java/Oops/backend/domain/terms/repository/TermsRepository.java
@@ -1,0 +1,12 @@
+package Oops.backend.domain.terms.repository;
+
+import Oops.backend.domain.terms.entity.RequiredType;
+import Oops.backend.domain.terms.entity.Terms;
+import org.springframework.data.repository.CrudRepository;
+
+import java.util.List;
+
+public interface TermsRepository extends CrudRepository<Terms, Long> {
+    List<Terms> findAllByRequired(RequiredType required);
+
+}

--- a/src/main/java/Oops/backend/domain/terms/repository/UserAndTermsRepository.java
+++ b/src/main/java/Oops/backend/domain/terms/repository/UserAndTermsRepository.java
@@ -1,0 +1,7 @@
+package Oops.backend.domain.terms.repository;
+
+import Oops.backend.domain.terms.entity.UserAndTerms;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserAndTermsRepository extends JpaRepository<UserAndTerms, Long> {
+}

--- a/src/main/java/Oops/backend/domain/terms/service/TermsService.java
+++ b/src/main/java/Oops/backend/domain/terms/service/TermsService.java
@@ -1,2 +1,23 @@
-package Oops.backend.domain.terms.service;public class TermsService {
+package Oops.backend.domain.terms.service;
+
+import Oops.backend.domain.terms.dto.response.TermsResponse;
+import Oops.backend.domain.terms.entity.Terms;
+import Oops.backend.domain.terms.repository.TermsRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class TermsService {
+
+    private final TermsRepository termsRepository;
+
+    public List<TermsResponse> getAllTerms() {
+        List<Terms> all = termsRepository.findAllByOrderByIdAsc();
+        return all.stream().map(TermsResponse::from).toList();
+    }
 }

--- a/src/main/java/Oops/backend/domain/terms/service/TermsService.java
+++ b/src/main/java/Oops/backend/domain/terms/service/TermsService.java
@@ -1,0 +1,2 @@
+package Oops.backend.domain.terms.service;public class TermsService {
+}


### PR DESCRIPTION
## #⃣ 연관된 이슈

> #256 

## 📝 작업 내용

> 회원가입 시 필수 동의 2개와 선택 동의 1개

### 📸 스크린샷 
<img width="500" height="732" alt="image" src="https://github.com/user-attachments/assets/b826aec6-f7a4-4a9e-9a92-5afc8d0e74f1" />  

[필수 동의 1을 false 할 시 회원가입 불가]
<img width="549" height="597" alt="image" src="https://github.com/user-attachments/assets/31a0554d-3a63-4075-873c-95b60154f55f" />
[필수 동의 1, 2 true 시 회원가입 가능]

<img width="556" height="957" alt="image" src="https://github.com/user-attachments/assets/09f3b21a-8695-40f8-9c8b-afc137911181" />  

[프런트에서 /terms 를 요청하여 약관동의 리스트를 얻을 수 있다.]
## 💬 리뷰 요구사항(선택)