### PR TITLE
[BUG] #282 이미지 반환 형식 변경

### DIFF
--- a/src/main/java/Oops/backend/domain/luckyDraw/dto/LuckyDrawResponse.java
+++ b/src/main/java/Oops/backend/domain/luckyDraw/dto/LuckyDrawResponse.java
@@ -1,6 +1,7 @@
 package Oops.backend.domain.luckyDraw.dto;
 
 import Oops.backend.domain.luckyDraw.entity.LuckyDraw;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/Oops/backend/domain/post/dto/PostResponse.java
+++ b/src/main/java/Oops/backend/domain/post/dto/PostResponse.java
@@ -3,6 +3,7 @@ package Oops.backend.domain.post.dto;
 import Oops.backend.domain.comment.dto.CommentResponse;
 import Oops.backend.domain.comment.model.CommentType;
 import Oops.backend.domain.post.entity.Post;
+import Oops.backend.config.s3.S3ImageService;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -29,8 +30,8 @@ public class PostResponse {
         int views;
         String image;  // 대표 이미지 한 장
 
-        public static PostPreviewDto from(Post post) {
-            return PostResponse.PostPreviewDto.builder()
+        public static PostPreviewDto from(Post post, String imageUrl) {
+            return PostPreviewDto.builder()
                     .postId(post.getId())
                     .title(post.getTitle())
                     .content(post.getContent())
@@ -38,7 +39,7 @@ public class PostResponse {
                     .likes(post.getLikes())
                     .comments(post.getComments() != null ? post.getComments().size() : 0)
                     .views(post.getWatching())
-                    .image(post.getImages() != null && !post.getImages().isEmpty() ? post.getImages().get(0) : null)
+                    .image(imageUrl)
                     .build();
         }
     }

--- a/src/main/java/Oops/backend/domain/post/service/SpecFeedServiceImpl.java
+++ b/src/main/java/Oops/backend/domain/post/service/SpecFeedServiceImpl.java
@@ -2,6 +2,7 @@ package Oops.backend.domain.post.service;
 
 import Oops.backend.common.exception.GeneralException;
 import Oops.backend.common.status.ErrorStatus;
+import Oops.backend.config.s3.S3ImageService;
 import Oops.backend.domain.category.repository.CategoryRepository;
 import Oops.backend.domain.category.repository.UserAndCategoryRepository;
 import Oops.backend.domain.post.dto.PostResponse;
@@ -32,6 +33,7 @@ public class SpecFeedServiceImpl implements SpecFeedService {
     private final UserAndCategoryRepository userAndCategoryRepository;
     private final CategoryRepository categoryRepository;
     private final RandomTopicRepository randomTopicRepository;
+    private final S3ImageService s3ImageService;
 
     /**
      * 베스트 게시글 전체 조회
@@ -164,7 +166,18 @@ public class SpecFeedServiceImpl implements SpecFeedService {
         }
 
         List<PostResponse.PostPreviewDto> previews = posts.getContent().stream()
-                .map(PostResponse.PostPreviewDto::from)
+                .map(post -> {
+                    String imageUrl = null;
+
+                    // 1) 이미지 키 뽑기
+                    if (post.getImages() != null && !post.getImages().isEmpty()) {
+                        String firstKey = post.getImages().get(0);
+                        imageUrl = s3ImageService.getPreSignedUrl(firstKey);
+                    }
+
+                    // 2) DTO 생성
+                    return PostResponse.PostPreviewDto.from(post, imageUrl);
+                })
                 .collect(Collectors.toList());
 
         return PostResponse.PostPreviewListDto.builder()


### PR DESCRIPTION
## #⃣ 연관된 이슈

> close #282 

## 📝 작업 내용

> DB에 저장된 이미지 경로 키(예: posts/f13d65ff-f_8.png) 문자열을 그대로 반환하는 방식에서 키 대신 S3 Pre-signed GET URL(예: https://{bucket}.s3.{region}.amazonaws.com/{key}?X-Amz-...)을 응답하도록 변경 