### PR TITLE
랜덤 주제 조회할 때 500 에러 수정

### DIFF
--- a/src/main/java/Oops/backend/common/status/ErrorStatus.java
+++ b/src/main/java/Oops/backend/common/status/ErrorStatus.java
@@ -44,6 +44,7 @@ public enum ErrorStatus {
     INVALID_POST_CONTEXT(HttpStatus.BAD_REQUEST, "POST400", "추천 기준이 되는 category나 topic이 없습니다."),
     UNAUTHORIZED_FOR_POST(HttpStatus.UNAUTHORIZED, "POST401", "게시글 삭제 권한이 없습니다."),
     ALREADY_LIKED_POST(HttpStatus.BAD_REQUEST, "POST405", "이미 응원한 게시글입니다."),
+    POST_CATEGORY_TOPIC_INVALID(HttpStatus.UNAUTHORIZED, "POST401", "카테고리 / 랜덤 주제 설정이 잘못된 게시글입니다."),
 
     // 댓글 관련 에러
     COMMENT_NOT_FOUND(HttpStatus.BAD_REQUEST, "COMMENT400", "존재하지 않는 댓글입니다."),

--- a/src/main/java/Oops/backend/domain/post/dto/PostResponse.java
+++ b/src/main/java/Oops/backend/domain/post/dto/PostResponse.java
@@ -24,18 +24,18 @@ public class PostResponse {
         Long postId;
         String title;
         String content;
-        String categoryName;
+        String categoryOrTopicName;
         int likes;
         int comments;
         int views;
         String image;  // 대표 이미지 한 장
 
-        public static PostPreviewDto from(Post post, String imageUrl) {
+        public static PostPreviewDto from(Post post, String CategoryOrTopicName, String imageUrl) {
             return PostPreviewDto.builder()
                     .postId(post.getId())
                     .title(post.getTitle())
                     .content(post.getContent())
-                    .categoryName(post.getCategory().getName())
+                    .categoryOrTopicName(CategoryOrTopicName)
                     .likes(post.getLikes())
                     .comments(post.getComments() != null ? post.getComments().size() : 0)
                     .views(post.getWatching())

--- a/src/main/java/Oops/backend/domain/post/service/HomeFeedServiceImpl.java
+++ b/src/main/java/Oops/backend/domain/post/service/HomeFeedServiceImpl.java
@@ -200,7 +200,7 @@ public class HomeFeedServiceImpl implements HomeFeedService {
                         String firstKey = post.getImages().get(0);
                         imageUrl = s3ImageService.getPreSignedUrl(firstKey);
                     }
-                    return PostResponse.PostPreviewDto.from(post, imageUrl);
+                    return PostResponse.PostPreviewDto.from(post, post.getCategory().getName(), imageUrl);
                 })
                 .collect(Collectors.toList());
         return bestPreviewDtos;

--- a/src/main/java/Oops/backend/domain/post/service/SpecFeedServiceImpl.java
+++ b/src/main/java/Oops/backend/domain/post/service/SpecFeedServiceImpl.java
@@ -167,16 +167,25 @@ public class SpecFeedServiceImpl implements SpecFeedService {
 
         List<PostResponse.PostPreviewDto> previews = posts.getContent().stream()
                 .map(post -> {
+                    String CategoryOrTopicName;
                     String imageUrl = null;
 
-                    // 1) 이미지 키 뽑기
+                    if (post.getCategory() != null && post.getTopic() == null) {        // 카테고리 게시물인 경우
+                        CategoryOrTopicName = post.getCategory().getName();
+                    } else if (post.getCategory() == null && post.getTopic() != null) {  // 랜덤 주제 게시물인 경우
+                        CategoryOrTopicName = post.getTopic().getName();
+                    } else{
+                        throw new GeneralException(ErrorStatus.POST_CATEGORY_TOPIC_INVALID, "카테고리 / 랜덤 주제 설정이 잘못된 게시글입니다.");
+                    }
+
+                    // 이미지 키 뽑기
                     if (post.getImages() != null && !post.getImages().isEmpty()) {
                         String firstKey = post.getImages().get(0);
                         imageUrl = s3ImageService.getPreSignedUrl(firstKey);
                     }
 
-                    // 2) DTO 생성
-                    return PostResponse.PostPreviewDto.from(post, imageUrl);
+                    // DTO 생성
+                    return PostResponse.PostPreviewDto.from(post, CategoryOrTopicName, imageUrl);
                 })
                 .collect(Collectors.toList());
 

--- a/src/main/java/Oops/backend/domain/randomTopic/Service/RandomTopicServiceImpl.java
+++ b/src/main/java/Oops/backend/domain/randomTopic/Service/RandomTopicServiceImpl.java
@@ -2,20 +2,13 @@ package Oops.backend.domain.randomTopic.Service;
 
 import Oops.backend.common.exception.GeneralException;
 import Oops.backend.common.status.ErrorStatus;
-import Oops.backend.domain.post.entity.Post;
-import Oops.backend.domain.post.repository.SpecFeedRepository;
 import Oops.backend.domain.randomTopic.Repository.RandomTopicRepository;
 import Oops.backend.domain.randomTopic.dto.RandomTopicResponse;
 import Oops.backend.domain.randomTopic.entity.RandomTopic;
 import Oops.backend.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.time.LocalDate;
-import java.time.LocalDateTime;
 
 @Service
 @RequiredArgsConstructor


### PR DESCRIPTION
## #⃣ 연관된 이슈

>close #288 

## 📝 작업 내용

> 현재 dto에서 카테고리 아이디를 반환하도록 되어있음 랜덤 주제일 경우 카테고리가 null이므로 이에 대한 분기 처리가 필요