### PR TITLE
bug: 댓글 삭제 권한, EC2 배포 서버 시간대 불일치 문제 해결

### DIFF
--- a/.github/workflows/oops-deploy.yml
+++ b/.github/workflows/oops-deploy.yml
@@ -96,5 +96,5 @@ jobs:
             sleep 10
             sudo fuser -k -n tcp 8080 || true
             
-            sudo nohup java -jar oops.jar > ./output.log 2>&1 &
+            sudo nohup java -Duser.timezone=Asia/Seoul -jar oops.jar > ./output.log 2>&1 &
             

--- a/src/main/java/Oops/backend/domain/comment/service/CommentCommandServiceImpl.java
+++ b/src/main/java/Oops/backend/domain/comment/service/CommentCommandServiceImpl.java
@@ -58,7 +58,7 @@ public class CommentCommandServiceImpl implements CommentCommandService{
         Post post = postQueryService.findPost(postId);
 
         // 게시글 작성한 사용자가 아니거나 댓글을 단 사용자가 아닐 경우 오류
-        if (post.getUser().equals(user1) || comment.getUser().equals(user1)){
+        if (!comment.getUser().equals(user1)){
             throw new GeneralException(ErrorStatus._BAD_REQUEST, "댓글 삭제 권한이 없습니다.");
         }
 


### PR DESCRIPTION
`close #{이슈 번호}`을 사용하면 PR이 merge되면 해당 이슈가 자동으로 닫힙니다.

## #⃣ 연관된 이슈

> ex) close #314 , close #315 

## 📝 작업 내용

> 게시글 작성자는 자신의 게시글에 작성된 댓글을 삭제할 수 있는 권한 제거
> 댓글 작성자가 자신의 댓글을 삭제할 권한이 없는 문제 수정
> EC2 인스턴스 환경의 시간대를 Asia, Seoul로 수정